### PR TITLE
Update main to v1.6.0 (#140 §14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Artifact Generator
 
 on: 
   push:
@@ -6,7 +6,11 @@ on:
       - '*'
 
 jobs:
-  build:
+  build_artifacts:
+    strategy:
+      max-parallel: 1
+      matrix:
+        php: [8.0.29, 8.2.10]
     runs-on: ubuntu-latest
 
     steps:
@@ -20,7 +24,7 @@ jobs:
       with:
         args: "--no-dev --working-dir=o3-shop"
         dev: no
-        php_version: "8.0.29"
+        php_version: ${{ matrix.php }}
         version: "2.2"
         php_extensions: zip exif
     - name: Pushes to another repository
@@ -35,5 +39,5 @@ jobs:
         user-name: 'O3-Shop'
         target-branch: releases
         create-target-branch-if-needed: false
-        commit-message: create monorepo from ORIGIN_COMMIT ($GITHUB_REF)
+        commit-message: create monorepo from ORIGIN_COMMIT ($GITHUB_REF) in PHP ${{ matrix.php }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        php: [8.0.29, 8.2.10]
+        php: [8.0.29, 8.1.26, 8.2.10]
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +28,7 @@ jobs:
         version: "2.2"
         php_extensions: zip exif
     - name: Pushes to another repository
-      uses: cpina/github-action-push-to-another-repository@main
+      uses: o3-shop/github-action-push-to-another-repository@main
       env:
         SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
       with:
@@ -39,5 +39,6 @@ jobs:
         user-name: 'O3-Shop'
         target-branch: releases
         create-target-branch-if-needed: false
-        commit-message: create monorepo from ORIGIN_COMMIT ($GITHUB_REF) in PHP ${{ matrix.php }}
+        commit-message: create monorepo from ORIGIN_COMMIT ($GITHUB_REF_NAME) in PHP ${{ matrix.php }}
+        tag-name: ${{ format('{0}_PHP_{1}', github.ref_name, matrix.php) }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,6 @@ jobs:
         user-name: 'O3-Shop'
         target-branch: releases
         create-target-branch-if-needed: false
-        commit-message: create monorepo from ORIGIN_COMMIT ($GITHUB_REF_NAME) in PHP ${{ matrix.php }}
+        commit-message: create monorepo from ORIGIN_COMMIT ${{ github.ref_name }} in PHP ${{ matrix.php }}
         tag-name: ${{ format('{0}_PHP_{1}', github.ref_name, matrix.php) }}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,35 @@
+name: Build and Push Shop Docker Image
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/o3shop-app
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Install Composer dependencies
+        run: |
+          composer create-project --no-dev o3-shop/o3-shop shop 1.4.1-BETA5
+
+      - name: Build Docker image
+        run: |
+          docker build -t $IMAGE_NAME:${{ github.ref_name }} .
+
+      - name: Push Docker image
+        run: |
+          docker push $IMAGE_NAME:${{ github.ref_name }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Install Composer dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+FROM php:8.2-apache
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    libjpeg-dev \
+    libpng-dev \
+    libfreetype6-dev \
+    libxml2-dev \
+    libcurl4-openssl-dev \
+    libonig-dev \
+    libzip-dev \
+    libssl-dev \
+    zlib1g-dev \
+    libicu-dev \
+    libxslt1-dev \
+    libbz2-dev \
+    libreadline-dev \
+    g++ \
+    unzip \
+    git \
+    nano \
+    sudo \
+    wget \
+    && apt-get install -y default-mysql-client
+
+# Configure and install PHP extensions
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) \
+        pdo \
+        pdo_mysql \
+        mysqli \
+        gd \
+        mbstring \
+        curl \
+        bcmath \
+        soap \
+        bz2 \
+        intl \
+        opcache \
+        calendar \
+        exif \
+        zip
+
+# Enable Apache mod_rewrite
+RUN a2enmod rewrite
+
+# Clean up to reduce image size
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /var/www/html
+
+COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
+
+RUN sed -i 's|DocumentRoot /var/www/html|DocumentRoot /var/www/html/source|g' /etc/apache2/sites-available/000-default.conf \
+    && sed -i '/<VirtualHost \*:80>/a <Directory /var/www/html/source>\n    Options Indexes FollowSymLinks\n    AllowOverride All\n    Require all granted\n</Directory>' /etc/apache2/sites-available/000-default.conf
+
+CMD ["docker/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
 RUN sed -i 's|DocumentRoot /var/www/html|DocumentRoot /var/www/html/source|g' /etc/apache2/sites-available/000-default.conf \
     && sed -i '/<VirtualHost \*:80>/a <Directory /var/www/html/source>\n    Options Indexes FollowSymLinks\n    AllowOverride All\n    Require all granted\n</Directory>' /etc/apache2/sites-available/000-default.conf
 
-CMD ["docker/entrypoint.sh"]
+COPY shop .

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ This package ist part of the O3-Shop. For more informations, consult the [docume
 
 ## Bugs and issues
 
-If you experience any bugs or issues, please report them in the section **O3-Shop (all versions)** of [https://issues.o3-shop.com](https://issues.o3-shop.com).
+If you experience any bugs or issues, please report them in the section **O3-Shop (all versions)** of [https://github.com/o3-shop/o3-shop/issues](https://github.com/o3-shop/o3-shop/issues).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # O3-Shop
 
-![O3-Shop logo](https://gitlab.o3-shop.com/o3/o3-documentation/-/raw/main/source/assets/logo.png "O3-Shop")
+![O3-Shop logo](https://www.o3-shop.com/wp-content/uploads/elementor/thumbs/o3-shop-logo-1-pw26sv9s5904cmoq6lyf07h4lpklvc6insy20a756o.png "O3-Shop")
 
 ## Project package
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "~v1.4.0"
+    "o3-shop/shop-metapackage-ce": "~v1.4.1-BETA1"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.1"
+    "o3-shop/shop-metapackage-ce": "v1.5.2-BETA1"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.3-RC4",
-    "o3-shop/shop-ce": "v1.5.3-RC4"
+    "o3-shop/shop-metapackage-ce": "v1.5.3"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
   ],
   "minimum-stability": "beta",
   "require": {
-    "o3-shop/shop-metapackage-ce": "1.5.2@beta",
-    "o3-shop/shop-ce": "1.5.2@beta"
+    "o3-shop/shop-metapackage-ce": "1.5.2-BETA3"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,6 @@
   "require": {
     "o3-shop/shop-metapackage-ce": "dev-b-1.6 as v1.5.4",
     "o3-shop/shop-ce": "dev-req/update-dependencies as v1.5.4",
-    "oxid-solution-catalysts/paypal-module": "dev-b-1.0",
-    "oxid-solution-catalysts/paypal-client": "dev-b-1.0",
     "o3-shop/shop-doctrine-migration-wrapper": "dev-b-1.6 as 1.0.2",
     "o3-shop/shop-db-views-generator": "^v1.0.0",
     "o3-shop/shop-demodata-installer": "dev-b-1.6 as 1.0.1",

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,37 @@
       "role": "Developer"
     }
   ],
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/o3-shop/paypal-module"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/o3-shop/paypal-client"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/nlo-tronet/shop-ce"
+    }
+  ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.4"
+    "o3-shop/shop-metapackage-ce": "dev-b-1.6 as v1.5.4-RC6",
+    "o3-shop/shop-ce": "dev-req/update-dependencies as v1.5.4",
+    "oxid-solution-catalysts/paypal-module": "dev-b-1.0",
+    "oxid-solution-catalysts/paypal-client": "dev-b-1.0",
+    "o3-shop/shop-doctrine-migration-wrapper": "dev-b-1.6 as 1.0.2",
+    "o3-shop/shop-db-views-generator": "^v1.0.0",
+    "o3-shop/shop-demodata-installer": "dev-b-1.6 as 1.0.1",
+    "o3-shop/shop-composer-plugin": "^v1.1.0",
+    "o3-shop/shop-unified-namespace-generator": "dev-b-1.6 as 1.0.1",
+    "o3-shop/shop-facts": "dev-b-1.6 as 1.0.4"
   },
   "require-dev": {
-    "o3-shop/testing-library": "^v1.0.0",
+    "o3-shop/testing-library": "dev-b-1.6 as 1.1.3",
     "incenteev/composer-parameter-handler": "^v2.0.0",
-    "o3-shop/shop-ide-helper": "^v1.0.0"
+    "o3-shop/shop-ide-helper": "dev-b-1.6 as 1.0.1"
   },
   "autoload-dev": {
     "psr-4": {
@@ -57,7 +80,8 @@
     },
     "allow-plugins": {
       "o3-shop/shop-composer-plugin": true,
-      "o3-shop/shop-unified-namespace-generator": true
+      "o3-shop/shop-unified-namespace-generator": true,
+      "composer/package-versions-deprecated": true
     }
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "beta",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.2-BETA",
+    "o3-shop/shop-metapackage-ce": "v1.5.2-BETA2",
     "o3-shop/shop-ce": "v1.5.2-BETA*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "dev-b-1.6 as v1.5.4-RC6",
+    "o3-shop/shop-metapackage-ce": "dev-b-1.6 as v1.5.4",
     "o3-shop/shop-ce": "dev-req/update-dependencies as v1.5.4",
     "oxid-solution-catalysts/paypal-module": "dev-b-1.0",
     "oxid-solution-catalysts/paypal-client": "dev-b-1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "~v1.3.0"
+    "o3-shop/shop-metapackage-ce": "~v1.4.0"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "~v1.4.1-BETA4@beta",
-    "o3-shop/shop-ce": "~v1.4.1-BETA3@beta"
+    "o3-shop/shop-metapackage-ce": "~v1.4.1",
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,9 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.4-RC1",
-    "o3-shop/shop-ce": "v1.5.4-RC1"
+    "o3-shop/shop-metapackage-ce": "v1.5.4-RC3",
+    "o3-shop/shop-ce": "v1.5.4-RC3",
+    "o3-shop/shop-doctrine-migration-wrapper": "v1.0.2-RC1"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.3-RC2",
-    "o3-shop/shop-ce": "v1.5.3-RC2"
+    "o3-shop/shop-metapackage-ce": "v1.5.3-RC3",
+    "o3-shop/shop-ce": "v1.5.3-RC3"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "beta",
   "require": {
-    "o3-shop/shop-metapackage-ce": "@beta",
+    "o3-shop/shop-metapackage-ce": "1.5.2@beta",
     "o3-shop/shop-ce": "1.5.2@beta"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "~v1.4.1-BETA1"
+    "o3-shop/shop-metapackage-ce": "~v1.4.1-BETA2@beta"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,9 @@
     }
   ],
   "minimum-stability": "beta",
-  "prefer-stable": true,
   "require": {
     "o3-shop/shop-metapackage-ce": "@beta",
-    "o3-shop/shop-ce": "1.5.*@beta"
+    "o3-shop/shop-ce": "1.5.2@beta"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
       "role": "Developer"
     }
   ],
-  "minimum-stability": "stable",
+  "minimum-stability": "BETA",
   "require": {
     "o3-shop/shop-metapackage-ce": "v1.5.2-BETA1"
   },

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
     }
   ],
   "minimum-stability": "beta",
+  "prefer-stable": true,
   "require": {
     "o3-shop/shop-metapackage-ce": "@beta",
-    "o3-shop/shop-ce": "@beta"
+    "o3-shop/shop-ce": "1.5.*@beta"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.3-RC",
-    "o3-shop/shop-ce": "v1.5.3-RC"
+    "o3-shop/shop-metapackage-ce": "v1.5.3-RC2",
+    "o3-shop/shop-ce": "v1.5.3-RC2"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -19,35 +19,14 @@
       "role": "Developer"
     }
   ],
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/o3-shop/paypal-module"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/o3-shop/paypal-client"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/nlo-tronet/shop-ce"
-    }
-  ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "dev-b-1.6 as v1.5.4",
-    "o3-shop/shop-ce": "dev-req/update-dependencies as v1.5.4",
-    "o3-shop/shop-doctrine-migration-wrapper": "dev-b-1.6 as 1.0.2",
-    "o3-shop/shop-db-views-generator": "^v1.0.0",
-    "o3-shop/shop-demodata-installer": "dev-b-1.6 as 1.0.1",
-    "o3-shop/shop-composer-plugin": "^v1.1.0",
-    "o3-shop/shop-unified-namespace-generator": "dev-b-1.6 as 1.0.1",
-    "o3-shop/shop-facts": "dev-b-1.6 as 1.0.4"
+    "o3-shop/shop-metapackage-ce": "v1.6.0-RC1",
   },
   "require-dev": {
-    "o3-shop/testing-library": "dev-b-1.6 as 1.1.3",
+    "o3-shop/testing-library": "^1.2.0",
     "incenteev/composer-parameter-handler": "^v2.0.0",
-    "o3-shop/shop-ide-helper": "dev-b-1.6 as 1.0.1"
+    "o3-shop/shop-ide-helper": "^1.0.1"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.3-RC3",
-    "o3-shop/shop-ce": "v1.5.3-RC3"
+    "o3-shop/shop-metapackage-ce": "v1.5.3-RC4",
+    "o3-shop/shop-ce": "v1.5.3-RC4"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.6.0-RC1",
+    "o3-shop/shop-metapackage-ce": "v1.6.0-RC1"
   },
   "require-dev": {
     "o3-shop/testing-library": "^1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "~v1.4.1",
+    "o3-shop/shop-metapackage-ce": "~v1.4.1"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,11 @@
     ],
     "oe:ide-helper:generate": [
       "if [ -f ./vendor/bin/oe-eshop-ide_helper ]; then oe-eshop-ide_helper; fi"
+    ],
+    "oe:module:install:paypal": [
+        "composer require oxid-solution-catalysts/paypal-module ^2.6.0",
+        "vendor/bin/oe-console oe:module:install-configuration source/modules/osc/paypal",
+        "vendor/bin/oe-console oe:cache:clear"
     ]
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
       "role": "Developer"
     }
   ],
-  "minimum-stability": "stable",
+  "minimum-stability": "RC",
   "require": {
     "o3-shop/shop-metapackage-ce": "v1.6.0-RC1"
   },

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   ],
   "minimum-stability": "beta",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.2-BETA2",
-    "o3-shop/shop-ce": "v1.5.2-BETA*"
+    "o3-shop/shop-metapackage-ce": "@beta",
+    "o3-shop/shop-ce": "@beta"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.0"
+    "o3-shop/shop-metapackage-ce": "v1.5.1"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
       "role": "Developer"
     }
   ],
-  "minimum-stability": "beta",
+  "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "1.5.2-BETA3"
+    "o3-shop/shop-metapackage-ce": "v1.5.2"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
       "role": "Developer"
     }
   ],
-  "minimum-stability": "BETA",
+  "minimum-stability": "beta",
   "require": {
     "o3-shop/shop-metapackage-ce": "v1.5.2-BETA1",
     "o3-shop/shop-ce": "v1.5.2-BETA1"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "~v1.4.1-BETA2@beta"
+    "o3-shop/shop-metapackage-ce": "~v1.4.1-BETA2@beta",
+    "o3-shop/shop-ce": "~v1.4.1-BETA1@beta"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "~v1.4.1-BETA3@beta",
-    "o3-shop/shop-ce": "~v1.4.1-BETA2@beta"
+    "o3-shop/shop-metapackage-ce": "~v1.4.1-BETA4@beta",
+    "o3-shop/shop-ce": "~v1.4.1-BETA3@beta"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.4-RC6",
-    "o3-shop/shop-ce": "v1.5.4-RC6",
-    "o3-shop/shop-doctrine-migration-wrapper": "v1.0.2-RC3"
+    "o3-shop/shop-metapackage-ce": "v1.5.4"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "RC",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.6.0-RC3"
+    "o3-shop/shop-metapackage-ce": "v1.6.0-RC4"
   },
   "require-dev": {
     "o3-shop/testing-library": "^1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.4.2"
+    "o3-shop/shop-metapackage-ce": "v1.5.0"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "RC",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.6.0-RC4"
+    "o3-shop/shop-metapackage-ce": "v1.6.0"
   },
   "require-dev": {
     "o3-shop/testing-library": "^1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.3"
+    "o3-shop/shop-metapackage-ce": "v1.5.4-RC1",
+    "o3-shop/shop-ce": "v1.5.4-RC1"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "RC",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.6.0-RC1"
+    "o3-shop/shop-metapackage-ce": "v1.6.0-RC2"
   },
   "require-dev": {
     "o3-shop/testing-library": "^1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "RC",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.6.0-RC2"
+    "o3-shop/shop-metapackage-ce": "v1.6.0-RC3"
   },
   "require-dev": {
     "o3-shop/testing-library": "^1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require-dev": {
     "o3-shop/testing-library": "^1.2.0",
     "incenteev/composer-parameter-handler": "^v2.0.0",
-    "o3-shop/shop-ide-helper": "^1.0.1"
+    "o3-shop/shop-ide-helper": "^1.0.0"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "~v1.4.1-BETA2@beta",
-    "o3-shop/shop-ce": "~v1.4.1-BETA1@beta"
+    "o3-shop/shop-metapackage-ce": "~v1.4.1-BETA3@beta",
+    "o3-shop/shop-ce": "~v1.4.1-BETA2@beta"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   ],
   "minimum-stability": "beta",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.2-BETA1",
-    "o3-shop/shop-ce": "v1.5.2-BETA1"
+    "o3-shop/shop-metapackage-ce": "v1.5.2-BETA",
+    "o3-shop/shop-ce": "v1.5.2-BETA*"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.2"
+    "o3-shop/shop-metapackage-ce": "v1.5.3-RC",
+    "o3-shop/shop-ce": "v1.5.3-RC"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.4-RC5",
-    "o3-shop/shop-ce": "v1.5.4-RC5",
-    "o3-shop/shop-doctrine-migration-wrapper": "v1.0.2-RC2"
+    "o3-shop/shop-metapackage-ce": "v1.5.4-RC6",
+    "o3-shop/shop-ce": "v1.5.4-RC6",
+    "o3-shop/shop-doctrine-migration-wrapper": "v1.0.2-RC3"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.4-RC3",
-    "o3-shop/shop-ce": "v1.5.4-RC3",
-    "o3-shop/shop-doctrine-migration-wrapper": "v1.0.2-RC1"
+    "o3-shop/shop-metapackage-ce": "v1.5.4-RC5",
+    "o3-shop/shop-ce": "v1.5.4-RC5",
+    "o3-shop/shop-doctrine-migration-wrapper": "v1.0.2-RC2"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "o3-shop/shop-metapackage-ce": "~v1.4.1"
+    "o3-shop/shop-metapackage-ce": "v1.4.2"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   ],
   "minimum-stability": "BETA",
   "require": {
-    "o3-shop/shop-metapackage-ce": "v1.5.2-BETA1"
+    "o3-shop/shop-metapackage-ce": "v1.5.2-BETA1",
+    "o3-shop/shop-ce": "v1.5.2-BETA1"
   },
   "require-dev": {
     "o3-shop/testing-library": "^v1.0.0",


### PR DESCRIPTION
Bring `main` up to the `v1.6.0` commit so it reflects the latest
released version, per #140 §14 (branch-model normalization).

Currently `main` on this repo is stale relative to the `v1.6.0` tag —
not "latest released code." This PR aligns it.

After this merges, the GitHub default branch will be flipped to
`main`. New clones will then land on `main` = `v1.6.0`-state.

Reviewable: the diff shows exactly the commits that have shipped to
consumers via `composer install` since main was last updated. No
unreleased work is being merged — branch source is the released tag,
not the in-development release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)