### PR TITLE
Run MigrationsRunner on post-update-cmd so auto-migration fires in production (#192)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
     "post-update-cmd": [
       "OxidEsales\\EshopCommunity\\Core\\ShopVersionGenerator::generate",
       "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
-      "@oe:ide-helper:generate"
+      "@oe:ide-helper:generate",
+      "OxidEsales\\EshopCommunity\\Core\\MigrationsRunner::run"
     ],
     "oe:ide-helper:generate": [
       "if [ -f ./vendor/bin/oe-eshop-ide_helper ]; then oe-eshop-ide_helper; fi"


### PR DESCRIPTION
Companion to **o3-shop/shop-ce#171** (issue #192).

## Why

shop-ce#171 adds `OxidEsales\EshopCommunity\Core\MigrationsRunner::run` to **shop-ce's** `post-update-cmd` so a server-side `composer update` auto-runs DB migrations + view regeneration. But Composer runs scripts **only from the root package** — and in a real deployment the root is *this* distribution, with shop-ce installed as a dependency. So the shop-ce entry alone never fires for end users.

The existing sibling entries (`ShopVersionGenerator::generate`, the Incenteev handler, the IDE helper) work in production precisely because they are declared **here** too. This PR gives the migration step the same treatment.

## Change

Append `OxidEsales\EshopCommunity\Core\MigrationsRunner::run` as the last `post-update-cmd` entry.

- Runs **after** Composer's package operations (the `shop-composer-plugin` file sync), so migrations execute against the updated file set.
- The runner self-guards (config exists → DB reachable via a 2s-timeout probe → shop launched) and **skips safely** (exit 0, calm one-line notice) when no usable DB is present — so `composer create-project`, CI artifact builds, and DB-less build steps are unaffected.
- `post-install-cmd` intentionally untouched, matching the shop-ce PR's scope.

## Merge ordering

Merge **after** shop-ce#171 lands and a shop-ce release carrying `MigrationsRunner` is referenced by the metapackage — otherwise `MigrationsRunner::run` won't resolve at composer time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VS5kXhvAyJqrsWWkwTjbd